### PR TITLE
Added option to "pass-through" emails to `Email.send`

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,6 @@
+#0.3.0
+* Added option to passThrough the email to `Email.send` via `emailStub/stubAndPassThrough`
+
 #0.2.0
 
 * Renamed the package to xolvio:email-stub to match meteor package name

--- a/README.md
+++ b/README.md
@@ -17,12 +17,14 @@ emails that are sent from your app will be captured wherever `Email.send` is
 used, such as accounts for verifying emails.
 
 You have 2 options to set up the stub:
+
 1. use `emailStub/stub` to create a "pure stub", meaning that Meteor will NOT
-send out any emails
+send out any emails.
+
 2. use `emailStub/stubAndPassThrough` to create a "passThrough-stub", meaning
 that meteor WILL still send out emails via `Email.send`. This enables you to
 preview your emails during development using tools like
-[MailDev ](https://github.com/djfarrelly/MailDev)
+[MailDev ](https://github.com/djfarrelly/MailDev).
 
 ####Set up "pure stub"
 ```javascript

--- a/README.md
+++ b/README.md
@@ -26,16 +26,16 @@ that meteor WILL still send out emails via `Email.send`. This enables you to
 preview your emails during development using tools like
 [MailDev ](https://github.com/djfarrelly/MailDev).
 
-####Set up "pure stub"
+####Set up stub
 ```javascript
+// OPTION 1 setup a "pure stub"
 Meteor.call('emailStub/stub');
 
 // or running with Chimp
 server.call('emailStub/stub');
-```
 
-####Set up "passThrough-stub" (and still have meteor send emails via `Email.send`)
-```javascript
+// OPTION 2: setup a "passThrough-stub" (and still have meteor send emails
+// via `Email.send`)
 Meteor.call('emailStub/stubAndPassThrough');
 
 // or running with Chimp

--- a/README.md
+++ b/README.md
@@ -16,7 +16,15 @@ Run a through your app manually, or using integration / end-to-end tests and
 emails that are sent from your app will be captured wherever `Email.send` is
 used, such as accounts for verifying emails.
 
-Set up
+You have 2 options to set up the stub:
+1. use `emailStub/stub` to create a "pure stub", meaning that Meteor will NOT
+send out any emails
+2. use `emailStub/stubAndPassThrough` to create a "passThrough-stub", meaning
+that meteor WILL still send out emails via `Email.send`. This enables you to
+preview your emails during development using tools like
+[MailDev ](https://github.com/djfarrelly/MailDev)
+
+####Set up "pure stub"
 ```javascript
 Meteor.call('emailStub/stub');
 
@@ -24,7 +32,15 @@ Meteor.call('emailStub/stub');
 server.call('emailStub/stub');
 ```
 
-Retrieve emails
+####Set up "passThrough-stub" (and still have meteor send emails via `Email.send`)
+```javascript
+Meteor.call('emailStub/stubAndPassThrough');
+
+// or running with Chimp
+server.call('emailStub/stubAndPassThrough');
+```
+
+####Retrieve emails
 ```javascript
 Meteor.call('emailStub/getEmails', function(e, emails) {
   console.log(emails);
@@ -78,7 +94,7 @@ locally.
 ### Testing lifecycle
 Set up
 ```javascript
-Meteor.call('emailStub/stub');
+Meteor.call('emailStub/stub');  // OR 'emailStub/stubAndPassThrough'
 ```
 
 Reset collection

--- a/email.js
+++ b/email.js
@@ -2,19 +2,30 @@
 
   'use strict';
 
-  var _emailsCollection = new Package.mongo.Mongo.Collection('emailsCollection');
+  const _emailsCollection = new Package.mongo.Mongo.Collection('emailsCollection');
+  const originalFunction = Email.send
 
   Meteor.methods({
-
     'emailStub/stub': function () {
-      Email.__send = Email.send;
+      originalFunction = Email.send;
       Email.send = function (options) {
         _emailsCollection.insert(options);
       };
     },
 
+    /**
+     * create stub and pass through the call to the original function.
+     * NOTE: read about monkey-patching best-practises at https://developer.mozilla.org/de/docs/Web/JavaScript/Reference/Global_Objects/Function/apply
+     */
+    'emailStub/stubAndPassThrough': function () {
+      Email.send = function (options) {
+        _emailsCollection.insert(options);
+        originalFunction.apply(this, [options]);  // pass through
+      }
+    },
+
     'emailStub/restore': function () {
-      Email.send = Email.__send;
+      Email.send = originalFunction;
     },
 
     'emailStub/reset': function () {

--- a/package.js
+++ b/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'xolvio:email-stub',
-  version: '0.2.0',
+  version: '0.3.0',
   summary: 'Allows you to inspect sent emails and assert on their content.',
   git: 'https://github.com/xolvio/meteor-email-stub',
   documentation: null,


### PR DESCRIPTION
Hi guys, 

I created this pull request to add the option to pass through emails to `Email.send`. It is backwards compatible and simple adds another method to call.

The cool thing is that this way we can use tools like MailDev (https://github.com/djfarrelly/MailDev) to preview our emails while developing.

See https://github.com/xolvio/meteor-email-stub/issues/4 for more details.